### PR TITLE
Refactor Windows APIs to prevent false-positive malware flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ windows = { version = "0.58", features = [
     "Win32_UI_Shell",
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
-    "Win32_System_ProcessStatus",
     "Win32_Security",
     "Win32_Graphics_Gdi",
     "Win32_System_Console",
+    "Win32_System_Registry",
 ] }
 tray-icon = "0.21"
 winit = "0.29"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,7 +136,7 @@ fn enable_autostart() -> Result<(), Box<dyn std::error::Error>> {
         );
         if result.is_err() {
             let _ = RegCloseKey(hkey);
-            return Err(windows::core::Error::from_win32().into());
+            return Err(windows::core::Error::from_hresult(result.to_hresult()).into());
         }
 
         let _ = RegCloseKey(hkey);
@@ -163,7 +163,7 @@ fn disable_autostart() -> Result<(), Box<dyn std::error::Error>> {
             &mut hkey,
         );
         if result.is_err() {
-            return Err(windows::core::Error::from_win32().into());
+            return Err(windows::core::Error::from_hresult(result.to_hresult()).into());
         }
 
         let value_name: Vec<u16> = "THide\0".encode_utf16().collect();
@@ -176,7 +176,7 @@ fn disable_autostart() -> Result<(), Box<dyn std::error::Error>> {
         } else if result == ERROR_FILE_NOT_FOUND {
             println!("Autostart was not enabled.");
         } else {
-            return Err(windows::core::Error::from_win32().into());
+            return Err(windows::core::Error::from_hresult(result.to_hresult()).into());
         }
     }
     Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,9 @@
-use windows::Win32::Foundation::{LPARAM, WPARAM};
+use windows::Win32::Foundation::{LPARAM, WPARAM, ERROR_FILE_NOT_FOUND};
 use windows::Win32::UI::WindowsAndMessaging::{FindWindowW, PostMessageW, WM_APP};
+use windows::Win32::System::Registry::{
+    RegCloseKey, RegDeleteValueW, RegOpenKeyExW, RegSetValueExW, HKEY_CURRENT_USER, KEY_SET_VALUE,
+    REG_SZ,
+};
 
 // Custom message IDs for IPC
 const WM_THIDE_SHOW: u32 = WM_APP + 1;
@@ -98,63 +102,84 @@ fn start_gui() -> Result<(), Box<dyn std::error::Error>> {
 
 /// Enable THide to start automatically on Windows login
 fn enable_autostart() -> Result<(), Box<dyn std::error::Error>> {
-    use std::process::Command;
-
     let exe_path = std::env::current_exe()?;
-    let exe_path_str = exe_path.to_string_lossy();
+    let exe_path_wide: Vec<u16> = exe_path
+        .to_string_lossy()
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect();
 
-    let output = Command::new("reg")
-        .args([
-            "add",
-            "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
-            "/v",
-            "THide",
-            "/t",
-            "REG_SZ",
-            "/d",
-            &exe_path_str,
-            "/f",
-        ])
-        .output()?;
+    unsafe {
+        let mut hkey = windows::Win32::System::Registry::HKEY::default();
+        let subkey: Vec<u16> = "Software\\Microsoft\\Windows\\CurrentVersion\\Run\0"
+            .encode_utf16()
+            .collect();
 
-    if output.status.success() {
-        println!("✓ Autostart enabled successfully!");
-        println!("  THide will start automatically when you log in.");
-        Ok(())
-    } else {
-        let error = String::from_utf8_lossy(&output.stderr);
-        eprintln!("Failed to enable autostart: {}", error);
-        std::process::exit(1);
+        RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            windows::core::PCWSTR(subkey.as_ptr()),
+            0,
+            KEY_SET_VALUE,
+            &mut hkey,
+        ).ok()?;
+
+        let value_name: Vec<u16> = "THide\0".encode_utf16().collect();
+        let result = RegSetValueExW(
+            hkey,
+            windows::core::PCWSTR(value_name.as_ptr()),
+            0,
+            REG_SZ,
+            Some(std::slice::from_raw_parts(
+                exe_path_wide.as_ptr() as *const u8,
+                exe_path_wide.len() * 2,
+            )),
+        );
+        if result.is_err() {
+            let _ = RegCloseKey(hkey);
+            return Err(windows::core::Error::from_win32().into());
+        }
+
+        let _ = RegCloseKey(hkey);
     }
+
+    println!("✓ Autostart enabled successfully!");
+    println!("  THide will start automatically when you log in.");
+    Ok(())
 }
 
 /// Disable THide autostart on Windows login
 fn disable_autostart() -> Result<(), Box<dyn std::error::Error>> {
-    use std::process::Command;
+    unsafe {
+        let mut hkey = windows::Win32::System::Registry::HKEY::default();
+        let subkey: Vec<u16> = "Software\\Microsoft\\Windows\\CurrentVersion\\Run\0"
+            .encode_utf16()
+            .collect();
 
-    let output = Command::new("reg")
-        .args([
-            "delete",
-            "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
-            "/v",
-            "THide",
-            "/f",
-        ])
-        .output()?;
+        let result = RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            windows::core::PCWSTR(subkey.as_ptr()),
+            0,
+            KEY_SET_VALUE,
+            &mut hkey,
+        );
+        if result.is_err() {
+            return Err(windows::core::Error::from_win32().into());
+        }
 
-    if output.status.success() {
-        println!("✓ Autostart disabled successfully!");
-        Ok(())
-    } else {
-        let error = String::from_utf8_lossy(&output.stderr);
-        if error.contains("unable to find") || error.contains("does not exist") {
+        let value_name: Vec<u16> = "THide\0".encode_utf16().collect();
+        let result = RegDeleteValueW(hkey, windows::core::PCWSTR(value_name.as_ptr()));
+
+        let _ = RegCloseKey(hkey);
+
+        if result.is_ok() {
+            println!("✓ Autostart disabled successfully!");
+        } else if result == ERROR_FILE_NOT_FOUND {
             println!("Autostart was not enabled.");
-            Ok(())
         } else {
-            eprintln!("Failed to disable autostart: {}", error);
-            std::process::exit(1)
+            return Err(windows::core::Error::from_win32().into());
         }
     }
+    Ok(())
 }
 
 /// Display CLI usage information

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,8 @@ use tray_icon::{
 use windows::Win32::Foundation::{
     GetLastError, ERROR_ALREADY_EXISTS, HANDLE, HWND, LPARAM, WPARAM,
 };
-use windows::Win32::System::ProcessStatus::GetModuleBaseNameW;
 use windows::Win32::System::Threading::{
-    CreateMutexW, OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ,
+    CreateMutexW, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT,
 };
 use windows::Win32::UI::Shell::{
     SHAppBarMessage, ABM_GETSTATE, ABM_SETSTATE, ABS_AUTOHIDE, APPBARDATA,
@@ -77,16 +76,19 @@ fn get_process_name(hwnd: HWND) -> Option<String> {
         let mut pid: u32 = 0;
         GetWindowThreadProcessId(hwnd, Some(&mut pid));
 
-        let h_process =
-            OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, pid).ok()?;
+        let h_process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()?;
 
-        let mut buffer: [u16; 512] = [0; 512];
-        let len = GetModuleBaseNameW(h_process, None, &mut buffer);
+        let mut buffer: [u16; 1024] = [0; 1024];
+        let mut size = buffer.len() as u32;
+        let result = QueryFullProcessImageNameW(h_process, PROCESS_NAME_FORMAT(0), windows::core::PWSTR(buffer.as_mut_ptr()), &mut size);
 
         let _ = windows::Win32::Foundation::CloseHandle(h_process);
 
-        if len > 0 {
-            Some(String::from_utf16_lossy(&buffer[..len as usize]))
+        if result.is_ok() {
+            let path = String::from_utf16_lossy(&buffer[..size as usize]);
+            std::path::Path::new(&path)
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
         } else {
             None
         }

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -124,7 +124,13 @@
                                 Name='thide.exe'
                                 DiskId='1'
                                 Source='$(var.CargoTargetBinDir)\thide.exe'
-                                KeyPath='yes'/>
+                                KeyPath='yes'>
+                                <Shortcut Id="ApplicationStartMenuShortcut"
+                                        Directory="ApplicationProgramsFolder"
+                                        Name="Taskbar Hide"
+                                        Description="A lightweight utility to hide/show Windows taskbar"
+                                        WorkingDirectory="Bin"/>
+                            </File>
                         </Component>
                     </Directory>
                 </Directory>
@@ -133,11 +139,6 @@
             <Directory Id="ProgramMenuFolder">
                 <Directory Id="ApplicationProgramsFolder" Name="Taskbar Hide">
                     <Component Id="ApplicationShortcut" Guid="D9C0B1E2-3F5A-4D8B-9E2F-1A7E8C9D3B4E">
-                        <Shortcut Id="ApplicationStartMenuShortcut"
-                                Name="Taskbar Hide"
-                                Description="A lightweight utility to hide/show Windows taskbar"
-                                Target="[#exe0]"
-                                WorkingDirectory="Bin"/>
                         <RemoveFolder Id="CleanUpShortCut" Directory="ApplicationProgramsFolder" On="uninstall"/>
                         <RegistryValue Root="HKCU" Key="Software\AmN\thide" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
                    </Component>


### PR DESCRIPTION
### Description
This PR addresses a false-positive virus detection (`Trojan:Script/Ulthar.A!ml`) introduced in the latest version by replacing "suspicious" application behaviors with cleaner, native Windows alternatives. 

### Changes
* **Native Registry Access**: The `enable-autostart` and `disable-autostart` commands now use the Windows Registry API (`RegOpenKeyExW`, `RegSetValueExW`, etc.) directly instead of calling the external `reg.exe` utility. Spawning system tools to modify the registry is a common trigger for machine-learning based detection.
* **Less Invasive Process Inspection**: The taskbar monitor now identifies `explorer.exe` using `QueryFullProcessImageNameW` with limited query permissions. This avoids the need for `PROCESS_VM_READ` (reading another process's memory), which is often flagged as malicious behavior.
* **Dependency Cleanup**: Removed the `Win32_System_ProcessStatus` feature from the `windows` crate as it is no longer needed.

These changes maintain all existing functionality while following more standard, less "noisy" Windows development patterns.